### PR TITLE
Use new bundle notation

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -2,7 +2,7 @@ setono_sylius_mailchimp_admin_audience:
     resource: |
         section: admin
         alias: setono_sylius_mailchimp.audience
-        templates: SyliusAdminBundle:Crud
+        templates: '@SyliusAdmin/Crud'
         only: ['index', 'update']
         permission: true
         redirect: update

--- a/src/Resources/views/Shop/_javascripts.html.twig
+++ b/src/Resources/views/Shop/_javascripts.html.twig
@@ -1,4 +1,4 @@
-{% include 'SyliusUiBundle::_javascripts.html.twig' with {'path': 'bundles/setonosyliusmailchimpplugin/js/shop/setono-mailchimp-subscribe.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {'path': 'bundles/setonosyliusmailchimpplugin/js/shop/setono-mailchimp-subscribe.js'} %}
 <script>
     $('form[name="setono_sylius_mailchimp_subscribe_to_newsletter"]').subscribeToNewsletter();
 </script>


### PR DESCRIPTION
Hi!
As reported [here](https://github.com/Sylius/SyliusThemeBundle/blob/master/UPGRADE.md#referencing-templates) the new SyliusThemeBundle has removed support for bundle notation while referencing templates. This PR will fix the problem. 