### PR TITLE
Make plugin compatible with Sylius 1.9 and Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
         "drewm/mailchimp-api": "^2.5",
-        "fzaninotto/faker": "^1.9",
+        "fakerphp/faker": "^1.9",
         "knplabs/knp-menu": "^3.1",
         "psr/log": "^1.1",
         "setono/doctrine-orm-batcher": "^0.6.2",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         "php": "^7.3",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "doctrine/doctrine-bundle": "^1.12.12",
+        "doctrine/doctrine-bundle": "^1.12.12 || ^2.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/orm": "^2.7",
-        "doctrine/persistence": "^1.3",
+        "doctrine/persistence": "^1.3 || ^2.0",
         "drewm/mailchimp-api": "^2.5",
         "fzaninotto/faker": "^1.9",
         "knplabs/knp-menu": "^3.1",
@@ -42,11 +42,12 @@
         "webmozart/assert": "^1.1"
     },
     "require-dev": {
+        "friendsofsymfony/oauth-server-bundle": "^1.6 || >2.0.0-alpha.0 ^2.0@dev",
         "phpspec/phpspec": "^6.3 || ^7.0",
         "phpunit/phpunit": "^9.4",
         "roave/security-advisories": "dev-master",
         "setono/code-quality-pack": "^1.1",
-        "sylius/sylius": "~1.7.0",
+        "sylius/sylius": "~1.9.0",
         "symfony/debug-bundle": "^5.1",
         "symfony/dotenv": "^5.1",
         "symfony/intl": "^4.4 || ^5.0",
@@ -73,7 +74,6 @@
             "tests/Application/Kernel.php"
         ]
     },
-    "prefer-stable": true,
     "scripts": {
         "all": [
             "@checks",

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -7,7 +7,6 @@ return [
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
     Sylius\Bundle\OrderBundle\SyliusOrderBundle::class => ['all' => true],
     Sylius\Bundle\MoneyBundle\SyliusMoneyBundle::class => ['all' => true],
     Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle::class => ['all' => true],
@@ -41,7 +40,7 @@ return [
     Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     Payum\Bundle\PayumBundle\PayumBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
-    WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle::class => ['all' => true],
+    BabDev\PagerfantaBundle\BabDevPagerfantaBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Sylius\Bundle\FixturesBundle\SyliusFixturesBundle::class => ['all' => true],
     Sylius\Bundle\PayumBundle\SyliusPayumBundle::class => ['all' => true],
@@ -53,4 +52,5 @@ return [
     Setono\DoctrineORMBatcherBundle\SetonoDoctrineORMBatcherBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
+    SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
 ];

--- a/tests/Application/config/packages/dev/jms_serializer.yaml
+++ b/tests/Application/config/packages/dev/jms_serializer.yaml
@@ -1,6 +1,11 @@
 jms_serializer:
     visitors:
-        json:
+        json_serialization:
+            options:
+                - JSON_PRETTY_PRINT
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION
+        json_deserialization:
             options:
                 - JSON_PRETTY_PRINT
                 - JSON_UNESCAPED_SLASHES

--- a/tests/Application/config/packages/doctrine_migrations.yaml
+++ b/tests/Application/config/packages/doctrine_migrations.yaml
@@ -1,5 +1,6 @@
 doctrine_migrations:
-    dir_name: "%kernel.project_dir%/src/Migrations"
-
-    # Namespace is arbitrary but should be different from App\Migrations as migrations classes should NOT be autoloaded
-    namespace: DoctrineMigrations
+    storage:
+        table_storage:
+            table_name: sylius_migrations
+    migrations_paths:
+        'App\Migrations': "%kernel.project_dir%/src/Migrations"

--- a/tests/Application/config/packages/jms_serializer.yaml
+++ b/tests/Application/config/packages/jms_serializer.yaml
@@ -1,4 +1,4 @@
 jms_serializer:
     visitors:
-        xml:
+        xml_serialization:
             format_output: '%kernel.debug%'

--- a/tests/Application/config/packages/prod/jms_serializer.yaml
+++ b/tests/Application/config/packages/prod/jms_serializer.yaml
@@ -1,6 +1,10 @@
 jms_serializer:
     visitors:
-        json:
+        json_serialization:
+            options:
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION
+        json_deserialization:
             options:
                 - JSON_UNESCAPED_SLASHES
                 - JSON_PRESERVE_ZERO_FRACTION


### PR DESCRIPTION
We had to update "doctrine/doctrine-bundle" and "doctrine/persistence" cause "symfony/doctrine-bridge" at version 5.2.0 requires "doctrine/persistence" ^2.0. Some one who wants to use Symfony 5.2 and has this plugin needs doctrin/persistence at ^2.0.

Than we needed to update the require dev of Sylius to 1.9 cause it's the only compatible with Symfony 5. We needed to add "friendsofsymfony/oauth-server-bundle" as done [here in the plugin skeleton](https://github.com/Sylius/PluginSkeleton/commit/aa3783c3ec6607046805fafd969212a95ed8091c) and dropped prefer-stable.