### PR TITLE
Adjust templates bundle referencing

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -3,7 +3,7 @@ setono_sylius_mailchimp_admin_audience:
         section: admin
         alias: setono_sylius_mailchimp.audience
         only: ['index', 'update']
-        templates: '@SyliusAdmin/Crud'
+        templates: '@SyliusAdmin\\Crud'
         permission: true
         redirect: update
         grid: setono_sylius_mailchimp_admin_audience


### PR DESCRIPTION
As shown [here](https://docs.sylius.com/en/1.8/cookbook/entities/custom-model.html#define-routing-for-entity-administration) Sylius use the double backslash to refer to the template in the controller. This also solves a problem using Symfony 5.2.