### PR TITLE
Change order of defined parameters

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -2,8 +2,8 @@ setono_sylius_mailchimp_admin_audience:
     resource: |
         section: admin
         alias: setono_sylius_mailchimp.audience
-        templates: '@SyliusAdmin/Crud'
         only: ['index', 'update']
+        templates: '@SyliusAdmin/Crud'
         permission: true
         redirect: update
         grid: setono_sylius_mailchimp_admin_audience


### PR DESCRIPTION
For some reason (I don't know at all, but got it already on multiple projects) we can not declare route with new syntax before another `'` has been written in a line. So we need to move this `only` before route name