### PR TITLE
Allow also psr/log ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/messenger": "^4.4 || ^5.4 || ^6.0",
         "symfony/options-resolver": "^4.4 || ^5.4 || ^6.0",
         "symfony/routing": "^4.4 || ^5.4 || ^6.0",
-        "symfony/translation-contracts": "^1.0 || ^2.0",
+        "symfony/translation-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/validator": "^4.4 || ^5.4 || ^6.0",
         "symfony/workflow": "^4.4 || ^5.4 || ^6.0",
         "thecodingmachine/safe": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drewm/mailchimp-api": "^2.5",
         "fakerphp/faker": "^1.20",
         "knplabs/knp-menu": "^3.3",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
         "setono/doctrine-orm-batcher": "^0.6.2",
         "setono/doctrine-orm-batcher-bundle": "^0.3.1",
         "sylius/resource-bundle": "^1.6",


### PR DESCRIPTION
There are no BC breaks between versions 1, 2 and 3 of psr/log so it's safe to allow all those versions. Sylius 1.12 requires psr/log 2 so if we want to use this plugin on newer versions of Sylius we have to do this change.